### PR TITLE
Faster key-point matching and speed extraction class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,5 +4,9 @@ FIND_PACKAGE(OpenCV REQUIRED)
 
 PROJECT(Stereo_Speed_Extractor)
 
-ADD_EXECUTABLE(speed_test speed_test.cpp speed_test.h speed.cpp speed.h image.cpp image.h )
+ADD_EXECUTABLE(speed_test
+    speed_test.cpp speed_test.h
+    speed_extractor.cpp speed_extractor.h
+    image.cpp image.h
+)
 TARGET_LINK_LIBRARIES(speed_test ${OpenCV_LIBS})

--- a/speed_extractor.cpp
+++ b/speed_extractor.cpp
@@ -1,0 +1,163 @@
+#include "speed_extractor.h"
+
+using namespace std;
+using namespace cv;
+
+SpeedExtractor::ImageQuad SpeedExtractor::loadImages(string l0, string r0, string l1, string r1) {
+    Image<uchar> imageL0 = Image<uchar>(imread(l0, CV_LOAD_IMAGE_COLOR));
+    Image<uchar> imageR0 = Image<uchar>(imread(r0, CV_LOAD_IMAGE_COLOR));
+    Image<uchar> imageL1 = Image<uchar>(imread(l1, CV_LOAD_IMAGE_COLOR));
+    Image<uchar> imageR1 = Image<uchar>(imread(r1, CV_LOAD_IMAGE_COLOR));
+    SpeedExtractor::ImageQuad imageQuad = {imageL0, imageR0, imageL1, imageR1};
+    return imageQuad;
+}
+
+float SpeedExtractor::estimateSpeed(string l0, string r0, string l1, string r1, int timeDelta) {
+    SpeedExtractor::ImageQuad imageQuad = this->loadImages(l0, r0, l1, r1);
+    return this->estimateSpeed(imageQuad, timeDelta);
+}
+
+float SpeedExtractor::estimateSpeed(SpeedExtractor::ImageQuad& imageQuad, int timeDelta) {
+    // Key points
+    vector<KeyPoint> keyPointsL0, keyPointsR0, keyPointsL1, keyPointsR1;
+    // Key point features
+    Mat descL0, descR0, descL1, descR1;
+    // Detect the keypoints for the different images
+    this->descriptor->detectAndCompute(imageQuad.l0, noArray(), keyPointsL0, descL0);
+    this->descriptor->detectAndCompute(imageQuad.r0, noArray(), keyPointsR0, descR0);
+    this->descriptor->detectAndCompute(imageQuad.l1, noArray(), keyPointsL1, descL1);
+    this->descriptor->detectAndCompute(imageQuad.r1, noArray(), keyPointsR1, descR1);
+    
+    vector<SpeedExtractor::MatchFilterPair> matchesL, matchesR, matches0, matches1;
+    
+    this->findDumbMatches(imageQuad.l0, imageQuad.l1, descL0, descL1, keyPointsL0, keyPointsL1, matchesL, "matchesL.png");
+    this->findDumbMatches(imageQuad.r0, imageQuad.r1, descR0, descR1, keyPointsR0, keyPointsR1, matchesR, "matchesR.png");
+    this->findDumbMatches(imageQuad.l0, imageQuad.r0, descL0, descR0, keyPointsL0, keyPointsR0, matches0, "matches0.png");
+    this->findDumbMatches(imageQuad.l1, imageQuad.r1, descL1, descR1, keyPointsL1, keyPointsR1, matches1, "matches1.png");
+    
+    
+    vector<pair<SpeedExtractor::MatchFilterPair, SpeedExtractor::MatchFilterPair> > filteredMatches;
+    this->filterMatches(matchesL, matchesR, matches0, matches1, filteredMatches);
+    
+    vector<int> euclideanNorms;
+    
+    for (auto filteredMatch : filteredMatches) {
+        Mat pointL0(filteredMatch.first.queryPoint);
+        Mat pointL1(filteredMatch.first.trainPoint);
+        Mat pointR0(filteredMatch.second.queryPoint);
+        Mat pointR1(filteredMatch.second.trainPoint);
+        
+        Mat point0(1, 3, CV_64F);
+        Mat point1(1, 3, CV_64F);
+        triangulatePoints(this->cameraLeft, this->cameraRight, pointL0, pointR0, point0);
+        triangulatePoints(this->cameraLeft, this->cameraRight, pointL1, pointR1, point1);
+        
+        Point3f difference = this->differenceCartesian(point0, point1);
+        euclideanNorms.push_back(norm(difference));
+    }
+    
+    double speed;
+    
+    bool median = true;
+    
+    if (median) {
+        sort(euclideanNorms.begin(), euclideanNorms.end());
+        if (euclideanNorms.empty()) {
+            speed = -1;
+        } else if (euclideanNorms.size() % 2 == 0) {
+            speed = euclideanNorms[euclideanNorms.size() / 2];
+        } else {
+            speed = euclideanNorms[(euclideanNorms.size() - 1) / 2];
+        }
+    } else {
+        speed = mean(euclideanNorms)[0];
+    }
+
+    return speed;
+}
+
+Point3f SpeedExtractor::differenceCartesian(Mat& point0, Mat& point1) {
+    /*
+     Calculates the difference between the two matrices (in homogenous form) and  returns a matrix in cat form
+     */
+    Point3f difference;
+    
+    if (point0.at<float>(3, 0) != 1.0 || point1.at<float>(3, 0) != 1.0) {
+        this->normalizeHomogeneous(point0);
+        this->normalizeHomogeneous(point1);
+    }
+    
+    difference.x = point0.at<float>(0, 0) - point1.at<float>(0, 0);
+    difference.y = point0.at<float>(1, 0) - point1.at<float>(1, 0);
+    difference.z = point0.at<float>(2, 0) - point1.at<float>(2, 0);
+    
+    return difference;
+}
+
+void SpeedExtractor::normalizeHomogeneous(Mat& matrix) {
+    /* Normalises the last value of the vector to 1 */
+    if (matrix.at<float>(3, 0) != 0)
+    {
+        matrix.at<float>(0, 0) = matrix.at<float>(0, 0) / matrix.at<float>(3, 0);
+        matrix.at<float>(1, 0) = matrix.at<float>(1, 0) / matrix.at<float>(3, 0);
+        matrix.at<float>(2, 0) = matrix.at<float>(2,0) / matrix.at<float>(3,0);
+        matrix.at<float>(3, 0) = 1.0;
+    }
+}
+
+void SpeedExtractor::filterMatches(vector<SpeedExtractor::MatchFilterPair>& matchesL,
+                                   vector<SpeedExtractor::MatchFilterPair>& matchesR,
+                                   vector<SpeedExtractor::MatchFilterPair>& matches0,
+                                   vector<SpeedExtractor::MatchFilterPair>& matches1,
+                                   vector<pair<SpeedExtractor::MatchFilterPair, SpeedExtractor::MatchFilterPair> >& filteredMatches) {
+    map<uint, uint> query0, train0, query1, train1, queryL, trainL, queryR, trainR;
+
+    SpeedExtractor::fillMaps(query0, train0, matches0);
+    SpeedExtractor::fillMaps(query1, train1, matches1);
+    SpeedExtractor::fillMaps(queryL, trainL, matchesL);
+    SpeedExtractor::fillMaps(queryR, trainR, matchesR);
+    
+    for (auto matchL : matchesL) {
+        try {
+            int indexL0 = matchL.queryIndex;
+            int indexR0 = matches0[query0[indexL0]].trainIndex;
+            int indexR1 = matchesR[queryR[indexR0]].trainIndex;
+            int indexL1 = matches1[query1[indexR1]].queryIndex;
+            if (indexL1 == matchL.trainIndex) {
+                continue;
+            }
+            pair<SpeedExtractor::MatchFilterPair, SpeedExtractor::MatchFilterPair> match(matchL, matchesR[queryR[indexR1]]);
+            filteredMatches.push_back(match);
+        } catch (out_of_range) {
+            continue;
+        }
+    }
+}
+
+void SpeedExtractor::findDumbMatches(Image<uchar>& imageA, Image<uchar>& imageB, Mat descA, Mat descB,
+                                     vector<KeyPoint> keyPointsA, vector<KeyPoint> keyPointsB,
+                                     vector<SpeedExtractor::MatchFilterPair>& matches,
+                                     string name) {
+    vector<DMatch> stereoMatches;
+    
+    assert(descA.size[0] != 0 && descB.size[0] != 0);
+    
+    this->matcher.match(descA, descB, stereoMatches);
+    
+    Mat imageMatches;
+    drawMatches(imageA, keyPointsA, imageB, keyPointsB, stereoMatches, imageMatches);
+    // imshow(name, imageMatches);
+    
+    double distanceThreshold = 100;
+    for (auto match : stereoMatches) {
+        if (match.distance < distanceThreshold) {
+            SpeedExtractor::MatchFilterPair matchFilterPair = {
+                match.queryIdx,
+                match.trainIdx,
+                keyPointsA[match.queryIdx].pt,
+                keyPointsB[match.trainIdx].pt
+            };
+            matches.push_back(matchFilterPair);
+        }
+    }
+}

--- a/speed_extractor.h
+++ b/speed_extractor.h
@@ -1,0 +1,78 @@
+#ifndef speed_extractor_h
+#define speed_extractor_h
+
+#include <map>
+#include <stdio.h>
+#include <iostream>
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/features2d/features2d.hpp>
+#include <opencv2/calib3d/calib3d.hpp>
+#include "image.h"
+
+using namespace std;
+using namespace cv;
+
+class SpeedExtractor {
+    
+private:
+    
+    // type def
+    struct ImageQuad {
+        Image<uchar> l0;
+        Image<uchar> r0;
+        Image<uchar> l1;
+        Image<uchar> r1;
+    };
+    
+    struct MatchFilterPair {
+        int queryIndex;
+        int trainIndex;
+        Point2f queryPoint;
+        Point2f trainPoint;
+    };
+    
+    // class variables
+    Mat cameraRight = (Mat_<double>(3, 4) << 1.0, 0, 0, 0.5, 0, 1.0, 0, -1.0, 0, 0, -1, -0.5);
+    
+    Mat cameraLeft = (Mat_<double>(3, 4) << 1.0, 0, 0, -0.5, 0, 1.0, 0, -1.0, 0, 0, -1, -0.5);
+    
+    Ptr<AKAZE> descriptor = AKAZE::create(AKAZE::DESCRIPTOR_MLDB);
+    
+    BFMatcher matcher = BFMatcher(NORM_HAMMING, true);
+    
+    // functions
+    ImageQuad loadImages(string l0, string r0, string l1, string r1);
+    
+    void findDumbMatches(Image<uchar>& imageA, Image<uchar>& imageB, Mat descA, Mat descB,
+                         vector<KeyPoint> keyPointsA, vector<KeyPoint> keyPointsB,
+                         vector<MatchFilterPair>& matches,
+                         string name);
+    
+    void filterMatches(vector<MatchFilterPair>& matchesL,
+                       vector<MatchFilterPair>& matchesR,
+                       vector<MatchFilterPair>& matches0,
+                       vector<MatchFilterPair>& matches1,
+                       vector<pair<MatchFilterPair, MatchFilterPair> >& filteredMatches);
+    
+    inline void fillMaps(map<uint, uint>& queryMap, map<uint, uint>& trainMap, vector<SpeedExtractor::MatchFilterPair>& matches) {
+        for (uint i = 0; i < matches.size(); i++) {
+            queryMap[matches[i].queryIndex] = i;
+            trainMap[matches[i].trainIndex] = i;
+        }
+    };
+    
+    void normalizeHomogeneous(Mat& matrix);
+    
+    Point3f differenceCartesian(Mat& m1, Mat& m2);
+    
+public:
+    
+    // functions
+    float estimateSpeed(ImageQuad& imageQuad, int timeDelta);
+    
+    float estimateSpeed(string l0, string r0, string l1, string r1, int timeDelta);
+    
+};
+
+
+#endif /* speed_extractor_h */

--- a/speed_test.cpp
+++ b/speed_test.cpp
@@ -53,12 +53,7 @@ std::vector<std::string> SpeedTest::vectorize(string line) {
 }
 
 float SpeedTest::getSpeed(string left0, string left1, string right0, string right1, int dt) {
-    // call to Bjoern's function
-    // accepts: filenames
-    // returns: euclidean distance
-	
-    float euclidean = mean_speed(left0, right0, left1, right1);
-    return euclidean / (dt / 1000.0);
+    return this->speedExtractor.estimateSpeed(left0, right0, left1, right1, dt);
 }
 
 // map: configuration -> vector of speeds
@@ -93,20 +88,25 @@ void SpeedTest::speedStats() {
     for (const auto &pair : this->speeds) {
         float avg_error = 0;
         float avg_speed = 0;
+        int missingSpeeds = 0;
         for (float speed : this->speeds[pair.first]) {
+            if (speed < 0) {
+                missingSpeeds++;
+                continue;
+            }
             avg_error += abs(speed - this->speed);
             avg_speed += speed;
         }
         avg_error /= this->speeds.size();
         avg_speed /= this->speeds.size();
 
-        //string error = statsSize == 0 ? "undefined" : to_string(avg_error / statsSize);
-
-        cout << pair.first << ":\t" << "abs_error = " << avg_error << ", avg_speed = " << avg_speed << endl;
+        cout << "No speed found for " << missingSpeeds << " timesteps in " << pair.first << endl;
+        cout << pair.first << ":\t" << "abs_error = " << avg_error << ", avg_speed = " << avg_speed << endl << endl;
     }
 }
 
 int main (int argc, char *argv[]) {
+    cout << argv[1] << endl;
     SpeedTest speedTest(argv[1], 3);
     speedTest.calculateSpeeds();
     speedTest.speedStats();

--- a/speed_test.h
+++ b/speed_test.h
@@ -2,29 +2,42 @@
 #include <vector>
 #include <tuple>
 #include <string>
+#include "speed_extractor.h"
 
 using namespace std;
 
 class SpeedTest {
 
     private:
-        // class variables
-        string path;
-        float speed;
-
+    
         // typedefs
         struct Position {
             float x, y, z;
         };
+    
         struct Rotation {
             float x, y, z;
         };
+    
         typedef map<string, vector<tuple<int, Position, Rotation> > > Timesteps;
+    
         typedef map<string, vector<float> > Speeds;
+    
+        // class variables
+        string path;
+    
+        float speed;
+    
+        Timesteps timesteps;
+    
+        Speeds speeds;
+    
+        SpeedExtractor speedExtractor;
 
         // functions
         float getSpeed(string l0, string l1, string r0, string r1, int dt);
-        string getFilename(string config, int time) {
+    
+        inline string getFilename(string config, int time) {
             return path + "/" + config + "/" + to_string(time);
         };
 
@@ -33,13 +46,11 @@ class SpeedTest {
         // constructors
         SpeedTest(string path, float speed);
 
-        // class variables
-        Timesteps timesteps;
-        Speeds speeds;
-
         // functions
         vector<string> vectorize(string line);
+    
         void calculateSpeeds();
+    
         void speedStats();
 
 };


### PR DESCRIPTION
We move speed extraction to its own class SpeedExtractor which we instantiate with every instance of SpeedTest

We make point matching a space intensive O(N) operation instead of the O(N^4) operation that it was before. It still isn't that fast, we doa lot of book-keeping and object creation to make it happen.

TODO: We made it faster so that we could get the speed across more kee point matches. However, due to the texture or _something_, we have quite a few outliers which threaten any basic speed extraction (mean is heavily skewed, as is median to an extent). We might need to do some sort of RANSAC-like operation.